### PR TITLE
fix: :sparkles: Added categories when fetching transactions

### DIFF
--- a/src/routes/profiles.ts
+++ b/src/routes/profiles.ts
@@ -121,8 +121,9 @@ router.get("/:id/transactions", (req: express.Request, res: express.Response, ne
           .where(
             "transaction.profileId = :profileId AND transaction.created >= :startDate AND transaction.created <= :endDate",
             { profileId: profile.id, startDate, endDate})
+          .leftJoinAndSelect("transaction.category", "categories")
           .limit(limit)
-          .offset(offset)
+          .offset(offset * limit)
           .getMany()
         // ####
           .then((transactions: Transaction[]) => {


### PR DESCRIPTION
Also tweaked pagination

I ran the tests and it seems as though all still passed - didn't have a chance to dig very far into them


```/usr/src/app # npm test

> finanzer@1.0.0 test
> NODE_ENV=test jest --runInBand --maxConcurrency=1

GET /check 200 2 - 1.705 ms
POST /profile/1/transactions/bulk 200 47 - 30.781 ms
GET /profile/2 200 95 - 1.902 ms
GET /profile/2 200 92 - 1.647 ms
GET /profile/20 404 149 - 12.805 ms
GET /profile/by_email/cool_kid@looserville.com 200 95 - 1.545 ms
GET /profile/by_email/happy_kid@coolville.com 404 179 - 10.689 ms
POST /profile 201 87 - 10.938 ms
PUT /profile/2 200 76 - 11.887 ms
PUT /profile/2 400 72 - 0.669 ms
PUT /profile/123 404 21 - 1.028 ms
 PASS  test/integration/app.test.ts
  ● Console

    console.log
      Server started on port: 3000

      at src/app.ts:86:13

GET /profile/5/transactions 200 1005 - 6.422 ms
GET /profile/5/transactions?page=1&per_page=1 200 252 - 3.468 ms
GET /profile/5/transactions?start_date=2021-01-01&end_date=2021-01-31 200 503 - 3.181 ms
POST /profile/5/transactions 400 76 - 1.638 ms
POST /profile/5/transactions 400 89 - 0.978 ms
 PASS  test/integration/transactions.test.ts
  ● Console

    console.log
      Server started on port: 3000

      at src/app.ts:86:13

POST /profile/6/transactions 200 347 - 10.412 ms
GET /profile/7/categories 200 30 - 3.116 ms
POST /profile/7/categories 201 118 - 13.055 ms
PUT /profile/7/categories/2 200 33 - 8.583 ms
 PASS  test/integration/categories.test.ts
  ● Console

    console.log
      Server started on port: 3000

      at src/app.ts:86:13


Test Suites: 3 passed, 3 total
Tests:       22 passed, 22 total
Snapshots:   0 total
Time:        5.525 s
Ran all test suites.
DELETE /profile/7/categories/4 200 43 - 6.156 ms
/usr/src/app # exit```